### PR TITLE
fix: Correct Calendly links and restore navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <!-- Navigation -->
 <nav class="sticky top-0 z-50 w-full border-b border-neutral-200 bg-white backdrop-blur-sm" role="navigation" aria-label="Main navigation">
   <div class="container">
-    <div class="flex min-h-16 items-center justify-between md:min-h-18">
+    <div class="flex min-h-16 items-center justify-center md:min-h-18">
       <!-- Desktop navigation - always visible -->
-      <div class="hidden sm:flex items-center justify-center flex-1">
+      <div class="hidden sm:flex items-center justify-center">
         <div class="flex items-center space-x-6 md:space-x-8">
           {% if page.url == "/" %}
             <a href="#benefits" class="text-md lg:text-base font-medium hover:text-primary transition-colors">Benefits</a>
@@ -23,37 +23,21 @@
         </div>
       </div>
 
-      <!-- Persistent CTA Button (Desktop) -->
-      <div class="hidden sm:block">
-        <a href="https://calendly.com/angel-dimitrov/ai-strategy-call"
-           class="btn-primary text-sm lg:text-base whitespace-nowrap"
-           target="_blank"
-           rel="noopener noreferrer">
-          Book Strategy Call
-        </a>
-      </div>
-
       <!-- Mobile navigation - priority items only -->
-      <div class="flex sm:hidden w-full justify-between items-center px-4">
-        <div class="flex items-center space-x-4">
+      <div class="flex sm:hidden w-full justify-center">
+        <div class="flex items-center space-x-6 px-4">
           {% if page.url == "/" %}
-            <a href="#services" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">Services</a>
-            <a href="{{ '/workshop/' | relative_url }}" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">Workshop</a>
-            <a href="{{ '/roi-calculator/' | relative_url }}" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">ROI</a>
+            <a href="#services" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">Services</a>
+            <a href="{{ '/workshop/' | relative_url }}" class="text-sm font-semibold text-primary hover:text-secondary transition-colors whitespace-nowrap bg-primary/8 px-3 py-2 rounded-lg">Workshop</a>
+            <a href="{{ '/roi-calculator/' | relative_url }}" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">ROI</a>
+            <a href="{{ '/tutorials/' | relative_url }}" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">Tutorials</a>
           {% else %}
-            <a href="/#services" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">Services</a>
-            <a href="{{ '/workshop/' | relative_url }}" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">Workshop</a>
-            <a href="{{ '/roi-calculator/' | relative_url }}" class="text-xs font-medium hover:text-primary transition-colors whitespace-nowrap">ROI</a>
+            <a href="/#services" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">Services</a>
+            <a href="{{ '/workshop/' | relative_url }}" class="text-sm font-semibold text-primary hover:text-secondary transition-colors whitespace-nowrap bg-primary/8 px-3 py-2 rounded-lg">Workshop</a>
+            <a href="{{ '/roi-calculator/' | relative_url }}" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">ROI</a>
+            <a href="{{ '/tutorials/' | relative_url }}" class="text-sm font-medium hover:text-primary transition-colors whitespace-nowrap">Tutorials</a>
           {% endif %}
         </div>
-
-        <!-- Persistent CTA Button (Mobile) -->
-        <a href="https://calendly.com/angel-dimitrov/ai-strategy-call"
-           class="btn-primary text-xs py-2 px-3 whitespace-nowrap"
-           target="_blank"
-           rel="noopener noreferrer">
-          Book Call
-        </a>
       </div>
     </div>
   </div>

--- a/roi-calculator.html
+++ b/roi-calculator.html
@@ -677,8 +677,8 @@ structured_data: |
         Let's discuss your specific context and create a tailored implementation plan that captures the full productivity potential for your team.
       </p>
       <div class="flex flex-col sm:flex-row justify-center items-center gap-4">
-        <a href="https://calendly.com/angel-dimitrov/roi-review-call" class="btn-primary" rel="noopener" target="_blank">
-          Book ROI Review Call (30 min)
+        <a href="https://calendly.com/angel-sourcestream/30min" class="btn-primary" rel="noopener" target="_blank">
+          Book Strategy Call (30 min)
         </a>
         <button
           id="shareUrlBtn"


### PR DESCRIPTION
## Summary
Fixes incorrect Calendly URLs introduced in Phase 3 and reverts navigation header to cleaner pre-Phase 3 design.

## Changes

### 1. Fixed Calendly Links
- **ROI Calculator**: Changed from `/angel-dimitrov/roi-review-call` to `/angel-sourcestream/30min`
- Updated button text from "Book ROI Review Call" to "Book Strategy Call (30 min)"

### 2. Restored Navigation Header
- **Removed** persistent CTA buttons from both desktop and mobile headers
- **Restored** mobile navigation to centered layout with Workshop highlighting
- **Added back** Tutorials link to mobile navigation
- **Improved** mobile navigation spacing and font sizes

## Why These Changes?

1. **Incorrect URLs**: Phase 3 introduced Calendly links using `/angel-dimitrov/` subdomain instead of the standard `/angel-sourcestream/30min` used throughout the site
2. **Navigation Simplicity**: Header CTA buttons added visual noise without clear conversion benefit
3. **Consistency**: Mobile navigation now matches the clean, focused design from before Phase 3

## What Remains from Phase 3?
- ✅ "Prefer email?" section in hero with enhanced mailto link
- ✅ Enhanced mailto links with pre-filled subjects throughout site
- ✅ ROI calculator soft handoff section (with corrected link)

## Files Changed
- `_includes/header.html` (-26 lines): Removed CTA buttons, restored centered navigation
- `roi-calculator.html` (2 lines): Fixed Calendly URL and button text

🤖 Generated with [Claude Code](https://claude.com/claude-code)